### PR TITLE
Parallel speedup

### DIFF
--- a/bin/prothint.py
+++ b/bin/prothint.py
@@ -538,6 +538,11 @@ def setEnvironment(args):
     genome = checkFileAndMakeAbsolute(args.genome)
     proteins = checkFileAndMakeAbsolute(args.proteins)
 
+    if args.ProSplign:
+        sys.exit("error: ProSplign is not supported in this version of ProtHint. "
+                 "For running ProtHint with ProSplign, use ProtHint release v2.4.0: "
+                 "https://github.com/gatech-genemark/ProtHint/releases/tag/v2.4.0")
+
     if args.geneMarkGtf:
         if args.geneSeeds:
             sys.exit("error: please specify either --geneSeeds or\n"
@@ -697,12 +702,7 @@ def parseCmd():
                         help='Scored hints from previous iteration.')
 
     parser.add_argument('--ProSplign',  default=False, action='store_true',
-                        help='Re-align hints discovered by Spaln with ProSplign and report ProSplign results. This is a legacy option which makes the pipeline \
-                        considerably (~20x) slower without a significant effect on the final accuracy.')
-    parser.add_argument('--maxSpalnCoverage', type=int, default=10,
-                        help='For each hint, select maxSpalnCoverage proteins for ProSplign realignment.')
-    parser.add_argument('--ensureDiamondPairs', type=int, default=5,
-                        help='Always align (with ProSplign) this many top proteins for each gene in DIAMOND output (no matter the Spaln result). Default = 5.')
+                        help=argparse.SUPPRESS)
 
     return parser.parse_args()
 

--- a/bin/run_spliced_alignment.pl
+++ b/bin/run_spliced_alignment.pl
@@ -348,10 +348,10 @@ sub printProgress
 {
 	my $permille = int(($counter * 1000) / $pairsCount);
 	if ($permille >= $nextPrint) {
-		printf STDERR "[" . localtime() . "] $counter/$pairsCount (%.1f%%) pairs aligned", $permille / 10 if $v;
+		printf STDERR "[" . localtime() . "] Enqueueing pair $counter/$pairsCount (%.1f%%)", $permille / 10 if $v;
 		$nextPrint = $permille + 1;
 		my $elapsedTime = time() - $startTime;
-		if ($permille == 0) {
+		if ($counter < $BATCH_SIZE * $cores * 8) {
 			print STDERR "\n" if $v;
 		} else {
 			my $secondsPerPermille = $elapsedTime / $permille;

--- a/bin/run_spliced_alignment_pbs.pl
+++ b/bin/run_spliced_alignment_pbs.pl
@@ -99,6 +99,7 @@ cp -r $bin/../dependencies/spaln_table dependencies
 cp $bin/../dependencies/spaln dependencies
 cp $bin/spaln_to_gff.py bin
 cp $bin/../dependencies/spaln_boundary_scorer dependencies
+cp $bin/spalnBatch.sh bin
 
 ./bin/run_spliced_alignment.pl --nuc $name --prot $db --list $list --cores $K --aligner spaln --min_exon_score $min_exon_score
 

--- a/bin/spalnBatch.sh
+++ b/bin/spalnBatch.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# ==============================================================
+# Tomas Bruna
+# Copyright 2020, Georgia Institute of Technology, USA
+#
+# Run Spaln on a list of genome-protein pairs
+# ==============================================================
+
+LONG_GENE=30000
+LONG_PROTEIN=15000
+
+if [ ! "$#" -eq 3 ]; then
+  echo "Usage: $0 input_batch output min_exon_score"
+  exit
+fi
+
+batchFile=$1
+output=$2
+min_exon_score=$3
+
+binDir="$(readlink -e $(dirname "$0"))"
+
+export ALN_TAB="$binDir/../dependencies/spaln_table"
+# Reset output
+echo -n "" > $output
+
+IFS=$'\t'
+
+while read -r -a pair; do
+
+  nuc=${pair[0]}
+  prot=${pair[1]}
+
+  geneLength=$(stat --printf "%s" "$nuc")
+  proteinLength=$(stat --printf "%s" "$prot")
+  # Estimate the maximum possible possible length of the alignment, including gaps.
+  alignmentLength="$(($geneLength*2))"
+
+  # -Q3    Algorithm runs in the fast heuristic mod
+  # -pw    Report result even if alignment score is below threshold prot_id
+  # -S1    Dna is in the forward orientation
+  # -LS    Smith-Waterman-type local alignment. This option may prune out weakly matched terminal regions.
+  # -O1    Output alignment
+  # -l     Number of characters per line in alignment
+
+  mode="-Q3"
+
+  # Mapping mode usually consumes less memory, use it for long alignments.
+  if [ $geneLength -gt $LONG_GENE ] || [ $proteinLength -gt $LONG_PROTEIN ]; then
+    mode="-Q7"
+  fi
+
+  # Align and directly parse the output
+  "$binDir/../dependencies/spaln" $mode -LS -pw -S1 -O1 -l $alignmentLength "$nuc" "$prot" \
+    2> /dev/null | "$binDir/../dependencies/spaln_boundary_scorer" -o "${nuc}_${prot}" -w 10 \
+    -s "$binDir/../dependencies/blosum62.csv" -e $min_exon_score
+
+  cat "${nuc}_${prot}" >> $output
+  rm "${nuc}_${prot}" "$nuc" "$prot"
+
+done < "$batchFile"


### PR DESCRIPTION
System calls in Perl are expensive. In the case of very fast Spaln alignments (for example short genes), the overhead of Perl system call is slower than the actual alignment. To reduce this problem, run Spaln in batches of 100 with a dedicated bash script.