### PR TITLE
spalnBatch.sh: increase spaln -l value so alignments don't span multiple lines

### DIFF
--- a/bin/spalnBatch.sh
+++ b/bin/spalnBatch.sh
@@ -35,7 +35,7 @@ while read -r -a pair; do
   geneLength=$(stat -c "%s" "$nuc")
   proteinLength=$(stat -c "%s" "$prot")
   # Estimate the maximum possible possible length of the alignment, including gaps.
-  alignmentLength="$(($geneLength*2))"
+  alignmentLength=$((2*(geneLength+proteinLength)))
 
   # -Q3    Algorithm runs in the fast heuristic mod
   # -pw    Report result even if alignment score is below threshold prot_id


### PR DESCRIPTION
While running BRAKER 2.1.6 with GeneMark 4.65, several segfaults were observed during the execution of spaln_boundary_scorer. This was traced to the spaln alignments spanning multiple lines (which is not supported by spaln_boundary_scorer), indicating that the `spaln -l` (maximum number of characters per line in the alignment) option-argument value isn't large enough. 

Example of input sequences:
[nuc_7658.gz](https://github.com/gatech-genemark/ProtHint/files/6519331/nuc_7658.gz)
[prot_7658.gz](https://github.com/gatech-genemark/ProtHint/files/6519332/prot_7658.gz)

spalnBatch.sh generated the following spaln command:
```
# export ALN_TAB=/opt/gmes_linux_64/ProtHint/bin/../dependencies/spaln_table
/opt/gmes_linux_64/ProtHint/bin/../dependencies/spaln -Q3 -LS -pw -S1 -O1 -l 9098 nuc_7658 prot_7658
```
which results in the spaln alignment being split over two sets of lines.

This PR suggests doubling the `spaln -l` option-argument value to attempt to ensure that the alignments don't span multiple lines. Note that increasing the `spaln -l` option appears to impact spaln memory usage, but this increase should be reasonable.